### PR TITLE
Added link to the restriction of trial accounts

### DIFF
--- a/docs/Working_in_the_Dev_Space_Manager_ad40d52.md
+++ b/docs/Working_in_the_Dev_Space_Manager_ad40d52.md
@@ -24,7 +24,7 @@ You can generate a dev space to create and manage applications. You can select t
 
 
 > ### Note:  
-> The maximum size limit of the dev space is 6GB for productive accounts and 2GB for trial accounts. Exceeding this limit may cause loss of data and other problems, including the inability to start the dev space.
+> The maximum size limit of the dev space is 6GB for productive accounts and 2GB for trial accounts. Exceeding this limit may cause loss of data and other problems, including the inability to start the dev space. Note that additional [restrictions](Restrictions_a45742a) apply to dev spaces in trial accounts.
 
 
 

--- a/docs/Working_in_the_Dev_Space_Manager_ad40d52.md
+++ b/docs/Working_in_the_Dev_Space_Manager_ad40d52.md
@@ -24,7 +24,7 @@ You can generate a dev space to create and manage applications. You can select t
 
 
 > ### Note:  
-> The maximum size limit of the dev space is 6GB for productive accounts and 2GB for trial accounts. Exceeding this limit may cause loss of data and other problems, including the inability to start the dev space. Note that additional [restrictions](Restrictions_a45742a) apply to dev spaces in trial accounts.
+> The maximum size limit of the dev space is 6GB for productive accounts and 2GB for trial accounts. Exceeding this limit may cause loss of data and other problems, including the inability to start the dev space. Note that additional [restrictions](Restrictions_a45742a.md) apply to dev spaces in trial accounts.
 
 
 


### PR DESCRIPTION
As the 2gb size limit is mentioned here I added a link to the list of all restrictions applying to trial accounts.