### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/community-id-requester.yaml
+++ b/.github/workflows/community-id-requester.yaml
@@ -34,11 +34,18 @@ jobs:
 
     steps:
 
+      - id: token_gen
+        name: Generate app installation token
+        uses: machine-learning-apps/actions-app-token@0.21
+        with:
+          APP_PEM: ${{ secrets.SAP_CODOC_APP_PEM_BASE64 }}
+          APP_ID: ${{ secrets.SAP_CODOC_APP_ID }}
+
       - id: checkout
         name: Check out the repo
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.token_gen.outputs.app_token }}
 
       - id: issue_details
         name: Determine related details if issue
@@ -60,7 +67,7 @@ jobs:
 
       - id: auth_gh
         name: Authenticate gh to repo
-        run: echo -n ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+        run: echo -n ${{ steps.token_gen.outputs.app_token }} | gh auth login --with-token
 
       - id: count_label_additions
         name: Count number of times label has been added

--- a/.github/workflows/disallowed-content-checks.yaml
+++ b/.github/workflows/disallowed-content-checks.yaml
@@ -2,7 +2,7 @@ name: Disallowed content checker
 
 # What the execution context is:
 # A pull request on the main branch. Only relevant for users who
-# are not members of the admin team for this repository.
+# don't have admin access on the repository.
 
 # What it does:
 # Checks to see if there are any files included in the pull request
@@ -16,9 +16,7 @@ name: Disallowed content checker
 # What's important to know:
 # The filter used in the check_files_changed step is a negated one,
 # i.e. notice the use of the '!'. Read the filter like this: "The
-# disallowed files are any that DON'T match docs/**". The membership
-# check is for the team defined in the env var in the step (currently
-# this is the '<repo>-admin' team.
+# disallowed files are any that DON'T match docs/**". 
 
 on:
   pull_request_target:
@@ -29,27 +27,32 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
+      - id: token_gen
+        name: Generate app installation token
+        uses: machine-learning-apps/actions-app-token@0.21
+        with:
+          APP_PEM: ${{ secrets.SAP_CODOC_APP_PEM_BASE64 }}
+          APP_ID: ${{ secrets.SAP_CODOC_APP_ID }}
+
       - id: checkout
         name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          token: ${{ steps.token_gen.outputs.app_token }}
 
       - id: auth_gh
         name: Authenticate gh to repo
-        run: echo -n ${{ secrets.SAPDOCS_Q_PAT_REPO_READORG }} | gh auth login --with-token
+        run: echo -n ${{ steps.token_gen.outputs.app_token }} | gh auth login --with-token
 
-      - id: check_membership
-        name: Check team membership of PR author
-        env:
-          team: 'admin'
+      - id: determine_permission
+        name: Look up actor's repository permission level
         run: |
-          IFS='/' read -r owner repository <<< "$GITHUB_REPOSITORY"
-          if gh api "/orgs/$owner/teams/${repository}-${team}/memberships/$GITHUB_ACTOR"; then
-            echo "is_team_member=true" >> $GITHUB_ENV
-          fi
+          permission="$(gh api --jq .permission "/repos/$GITHUB_REPOSITORY/collaborators/$GITHUB_ACTOR/permission")"
+          echo "repo_permission=$permission" >> $GITHUB_ENV
 
       - id: check_files_changed
         name: Checks if disallowed content has been changed
-        if: env.is_team_member != 'true'
+        if: env.repo_permission != 'admin'
         uses: dorny/paths-filter@v2
         with:
           list-files: 'shell'
@@ -58,7 +61,7 @@ jobs:
               - '!docs/**'
 
       - id: comment_on_disallowed
-        if: env.is_team_member != 'true' && steps.check_files_changed.outputs.disallowed == 'true'
+        if: steps.check_files_changed.outputs.disallowed == 'true'
         env:
           DOCS_LOC: "/${{ github.repository }}/tree/${{ github.base_ref }}/docs"
           REVERT_COMMAND: '`git checkout origin/main <filename>`'

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -29,6 +29,14 @@ jobs:
       name: Check out the repository content
       uses: actions/checkout@v2
 
+    - id: check_files_changed
+      uses: dorny/paths-filter@v2
+      with:
+        list-files: 'escape'
+        filters: |
+          changed:
+            - 'docs/**'
+
     - id: add_matcher
       name: Add the matcher for markdownlint style message output
       run: "echo ::add-matcher::.github/workflows/markdownlint/problem-matcher.json"
@@ -42,9 +50,10 @@ jobs:
           markdownlint-cli markdownlint-rule-titlecase
 
     - id: run_linter
+      if: steps.check_files_changed.outputs.changed_files
       name: Run linter with specific rules, on the docs/ content
       run: |
         npx markdownlint \
           --config .github/workflows/markdownlint/config.yaml \
           --rules markdownlint-rule-titlecase \
-          docs/
+          ${{ steps.check_files_changed.outputs.changed_files }}

--- a/.github/workflows/merged-pr-labeler.yaml
+++ b/.github/workflows/merged-pr-labeler.yaml
@@ -29,13 +29,22 @@ jobs:
 
     steps:
 
+      - id: token_gen
+        name: Generate app installation token
+        uses: machine-learning-apps/actions-app-token@0.21
+        with:
+          APP_PEM: ${{ secrets.SAP_CODOC_APP_PEM_BASE64 }}
+          APP_ID: ${{ secrets.SAP_CODOC_APP_ID }}
+
       - id: checkout
         name: Check out the repo
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.token_gen.outputs.app_token }}
+
+      - id: auth_gh
+        name: Authenticate gh to repo
+        run: echo -n ${{ steps.token_gen.outputs.app_token }} | gh auth login --with-token
 
       - id: assign_label
-        run: |
-          echo -n ${{ secrets.PAT }} | gh auth login --with-token
-          gh pr edit ${{ github.event.number }} --add-label "$LABEL"
+        run: gh pr edit ${{ github.event.number }} --add-label "$LABEL"


### PR DESCRIPTION
Some updates to the worfklows:

- move away from PATs to using GitHub app based auth
- improvement to the administration role checking in 'disallowed-checker'

Once this PR is merged, we can remove `PAT` and `SAPDOCS_Q_PAT_REPO_READORG` secrets.
