### PR TITLE
fix: Capitalization consistency

### DIFF
--- a/docs/Connecting_to_a_Public_Git_Repository_a47db8b.md
+++ b/docs/Connecting_to_a_Public_Git_Repository_a47db8b.md
@@ -2,7 +2,7 @@
 
 # Connecting to a Public Git Repository
 
-Using SAP Business Application Studio, can connect to all public git services, such as GitHub, GitLab, and Gitbucket.
+Using SAP Business Application Studio, can connect to all public git services, such as GitHub, GitLab, and GitBucket.
 
 
 


### PR DESCRIPTION
Nit picky detail: changed capitalization of 'GitBucket' to the 'official' CamelCase writing to be consistent with the other mentioned services