### PR TITLE
Update Full_Stack_Cloud_Application_de0af65.md

### DIFF
--- a/docs/Full_Stack_Cloud_Application_de0af65.md
+++ b/docs/Full_Stack_Cloud_Application_de0af65.md
@@ -20,7 +20,7 @@ The Full Stack Cloud Application scenario contains the following predefined exte
 
     Allows you to develop, test, and run Java applications. Includes debugging capabilities and enhanced code editors. The following tools are installed as part of the extension:
 
-    -   SapMachine11
+    -   SapMachine 11
 
     -   Maven V 3.8.1
 


### PR DESCRIPTION
Line number 23:
Original: SapMachine11
Proposed: SapMachine 11
Justification:
I had looked into some documentation, which mentioned as "SapMachine 11" with space between "SapMachine" and "11".
Below is the referred documentation link.
https://help.sap.com/viewer/9734df69fa0e411381929174bb064d9e/2.0.11_Corr/en-US/65f84c0bcdb340c3bd51efc1c358d4f5.html