### PR TITLE
use custom heading increment rule for markdown checks

### DIFF
--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -42,12 +42,12 @@ jobs:
       run: "echo ::add-matcher::.github/workflows/markdownlint/problem-matcher.json"
 
     - id: install_linter
-      name: Install linting tool and custom rule
+      name: Install linting tool, custom rule and rule helpers
       run: |
         npm install \
           --no-package-lock \
           --no-save \
-          markdownlint-cli markdownlint-rule-titlecase
+          markdownlint-cli markdownlint-rule-titlecase markdownlint-rule-helpers
 
     - id: run_linter
       if: steps.check_files_changed.outputs.changed_files
@@ -55,5 +55,6 @@ jobs:
       run: |
         npx markdownlint \
           --config .github/workflows/markdownlint/config.yaml \
+          --rules .github/workflows/markdownlint/md901 \
           --rules markdownlint-rule-titlecase \
           ${{ steps.check_files_changed.outputs.changed_files }}

--- a/.github/workflows/markdownlint/config.yaml
+++ b/.github/workflows/markdownlint/config.yaml
@@ -3,8 +3,8 @@ default: false
 
 # These specific rules are active.
 # See https://github.com/DavidAnson/markdownlint#rules--aliases for details.
-heading-increment: true
 no-reversed-links: true
 no-missing-space-atx: true
 no-multiple-space-atx: true
 titlecase-rule: true
+heading-increment-no-blockquote: true

--- a/.github/workflows/markdownlint/md901.js
+++ b/.github/workflows/markdownlint/md901.js
@@ -1,0 +1,23 @@
+// @ts-check
+
+"use strict";
+
+const { addErrorDetailIf, filterTokens } = require("markdownlint-rule-helpers");
+
+module.exports = {
+  "names": [ "MD901", "heading-increment-no-blockquote" ],
+  "description": "Custom version of MD001. Heading levels should only increment by one level at a time, except if in a blockquote",
+  "tags": [ "headings", "headers" ],
+  "function": function MD901(params, onError) {
+    let prevLevel = 0;
+    filterTokens(params, "heading_open", function forToken(token) {
+      const level = Number.parseInt(token.tag.slice(1), 10);
+      if (token.line.match(/^\s*> ?/)) return;
+      if (prevLevel && (level > prevLevel)) {
+        addErrorDetailIf(onError, token.lineNumber,
+          "h" + (prevLevel + 1), "h" + level);
+      }
+      prevLevel = level;
+    });
+  }
+};


### PR DESCRIPTION
An update to the Markdown checks to replace the standard [MD001 rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md001---heading-levels-should-only-increment-by-one-level-at-a-time) with a custom version that takes into account our use of heading indicators within the context of a note, e.g. `> ### Note:`.